### PR TITLE
Allow address to be customized with an ENV variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt::fmt().without_time().with_env_filter(filter).init();
 
     let title = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "".to_string());
+    let address = std::env::var("WASM_SERVER_RUNNER_ADDRESS").unwrap_or_else(|_| "127.0.0.1".to_string());
 
-    let options = Options { title };
+    let options = Options { title, address };
 
     let wasm_file = std::env::args()
         .nth(1)

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,6 +16,7 @@ fn generate_version() -> String {
 
 pub struct Options {
     pub title: String,
+    pub address: String,
 }
 
 pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<()> {
@@ -43,8 +44,11 @@ pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<(
         .fallback(serve_dir)
         .layer(middleware_stack);
 
-    let port = pick_port::pick_free_port(1334, 10).unwrap_or(1334);
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let mut address_string = options.address;
+    if !address_string.contains(":") {
+        address_string += &(":".to_owned() + &pick_port::pick_free_port(1334, 10).unwrap_or(1334).to_string());
+    }
+    let addr: SocketAddr = address_string.parse().expect("Couldn't parse address");
 
     tracing::info!("starting webserver at http://{}", addr);
     axum::Server::bind(&addr).serve(app.into_make_service()).await?;


### PR DESCRIPTION
I am re-submitting #1 with the desired changes mentioned below:

> @peterbraden could you rename the variable to `WASM_SERVER_RUNNER_ADDRESS`? Otherwise this looks good to merge.

