### PR TITLE
Explicitly state that the size listed is the compressed size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let output = wasm_bindgen::generate(&wasm_file)?;
 
-    info!("wasm output is {} large", pretty_size(output.compressed_wasm.len()));
+    info!("compressed wasm output is {} large", pretty_size(output.compressed_wasm.len()));
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(server::run_server(options, output))?;


### PR DESCRIPTION
I was confused for a bit why the sizes I saw on the disk and in the server runner didn't match. Needed to read the source to find that the size listed was actually the compressed size. I think it's better to be explicit about this.