### PR TITLE
Add COOP and COEP headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ wasm-bindgen-cli-support = "0.2"
 
 axum = { version = "0.5", default-features = false, features = ["http1", "headers"] }
 tokio = { version = "1.11", default-features = false, features = ["rt-multi-thread"] }
-tower-http = { version = "0.2", features = ["fs", "trace"] }
+tower-http = { version = "0.2", features = ["fs", "set-header", "trace"] }
 tower = "0.4"
 fastrand = "1.5"
 flate2 = "1.0"


### PR DESCRIPTION
See #8.
Fixed according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements.

Fixes #8.