### PR TITLE
Implement self-signed certificate option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wasm-bindgen-cli-support = "0.2"
 
 axum = { version = "0.5", default-features = false, features = ["http1", "headers"] }
+axum-server = { version = "0.4", features = ["tls-rustls"] }
 tokio = { version = "1.11", default-features = false, features = ["rt-multi-thread"] }
 tower-http = { version = "0.2", features = ["fs", "trace"] }
 tower = "0.4"
 fastrand = "1.5"
 flate2 = "1.0"
+rcgen = { version = "0.9", default-features = false }

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@ use axum::http::{HeaderValue, StatusCode};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, get_service};
 use axum::{Router, TypedHeader};
+use axum_server::tls_rustls::RustlsConfig;
 use tower::ServiceBuilder;
 use tower_http::services::ServeDir;
 
@@ -50,8 +51,20 @@ pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<(
     }
     let addr: SocketAddr = address_string.parse().expect("Couldn't parse address");
 
-    tracing::info!("starting webserver at http://{}", addr);
-    axum::Server::bind(&addr).serve(app.into_make_service()).await?;
+    if std::env::var("WASM_SERVER_RUNNER_HTTPS").unwrap_or_else(|_| String::from("0")) == "1" {
+        let certificate = rcgen::generate_simple_self_signed([])?;
+        let config = RustlsConfig::from_der(
+            vec![certificate.serialize_der()?],
+            certificate.serialize_private_key_der(),
+        )
+        .await?;
+
+        tracing::info!("starting webserver at https://{}", addr);
+        axum_server::bind_rustls(addr, config).serve(app.into_make_service()).await?;
+    } else {
+        tracing::info!("starting webserver at http://{}", addr);
+        axum_server::bind(addr).serve(app.into_make_service()).await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This implements an option to use HTTPS with a self-signed certificate via `WASM_SERVER_RUNNER_HTTPS`.

This is necessary because some features don't work if the website doesn't use HTTPS.
To implement this I used [`axum-server`](https://crates.io/crates/axum-server), which is also used by the [official HTTPS example](https://github.com/tokio-rs/axum/blob/1ace8554ce22cb8086358a19ca4882a6d86a354f/examples/tls-rustls/src/main.rs). If this is undesired I can also write a more manual implementation based on `tokio-rustls`, following [another official example](https://github.com/tokio-rs/axum/blob/1ace8554ce22cb8086358a19ca4882a6d86a354f/examples/low-level-rustls/src/main.rs).

I'm aware this might be a bit out of scope for this project!