### PR TITLE
Compress all other served files automatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ wasm-bindgen-cli-support = "0.2"
 axum = { version = "0.5", default-features = false, features = ["http1", "headers"] }
 axum-server = { version = "0.4", features = ["tls-rustls"] }
 tokio = { version = "1.11", default-features = false, features = ["rt-multi-thread"] }
-tower-http = { version = "0.3", features = ["fs", "set-header", "trace"] }
+tower-http = { version = "0.3", features = ["compression-full", "fs", "set-header", "trace"] }
 tower = "0.4"
 fastrand = "1.5"
 flate2 = "1.0"

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,6 +7,7 @@ use axum::routing::{get, get_service};
 use axum::{Router, TypedHeader};
 use axum_server::tls_rustls::RustlsConfig;
 use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
 use tower_http::services::ServeDir;
 use tower_http::set_header::SetResponseHeaderLayer;
 
@@ -27,6 +28,7 @@ pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<(
     let WasmBindgenOutput { js, compressed_wasm } = output;
 
     let middleware_stack = ServiceBuilder::new()
+        .layer(CompressionLayer::new())
         .layer(SetResponseHeaderLayer::if_not_present(
             HeaderName::from_static("cross-origin-opener-policy"),
             HeaderValue::from_static("same-origin"),


### PR DESCRIPTION
Follow up on #15. This leaves the compression of the WASM file untouched.