### PR TITLE
Replace GZIP compression with Brotli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ tokio = { version = "1.11", default-features = false, features = ["rt-multi-thre
 tower-http = { version = "0.3", features = ["fs", "set-header", "trace"] }
 tower = "0.4"
 fastrand = "1.5"
-flate2 = "1.0"
+brotli = { version = "3", default-features = false, features = ["std"]}
 rcgen = { version = "0.9", default-features = false }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,10 @@
 use std::net::SocketAddr;
 
-use axum::headers::{ContentEncoding, HeaderName};
+use axum::headers::HeaderName;
 use axum::http::{HeaderValue, StatusCode};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, get_service};
-use axum::{Router, TypedHeader};
+use axum::Router;
 use axum_server::tls_rustls::RustlsConfig;
 use tower::ServiceBuilder;
 use tower_http::services::ServeDir;
@@ -44,7 +44,7 @@ pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<(
     let serve_dir = get_service(ServeDir::new(".")).handle_error(internal_server_error);
 
     let serve_wasm = || async move {
-        (TypedHeader(ContentEncoding::gzip()), WithContentType("application/wasm", compressed_wasm))
+        ([("content-encoding", "br")], WithContentType("application/wasm", compressed_wasm))
     };
 
     let app = Router::new()


### PR DESCRIPTION
Follow-up on #15. This replaces the GZIP compression with Brotli. This shouldn't be a problem as all browsers support Brotli nowadays, see https://caniuse.com/brotli.

My WASM files are now consistently about a third smaller.