### PR TITLE
Implement ability to generate non-module JS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,10 @@ fn main() -> Result<(), anyhow::Error> {
         std::env::var("WASM_SERVER_RUNNER_ADDRESS").unwrap_or_else(|_| "127.0.0.1".to_string());
     let https =
         std::env::var("WASM_SERVER_RUNNER_HTTPS").unwrap_or_else(|_| String::from("0")) == "1";
+    let no_module =
+        std::env::var("WASM_SERVER_RUNNER_NO_MODULE").unwrap_or_else(|_| String::from("0")) == "1";
 
-    let options = Options { title, address, https };
+    let options = Options { title, address, https, no_module };
 
     let wasm_file = std::env::args()
         .nth(1)
@@ -32,7 +34,7 @@ fn main() -> Result<(), anyhow::Error> {
     let is_wasm_file = wasm_file.extension().map_or(false, |e| e == "wasm");
     ensure!(is_wasm_file, "expected to be run with a wasm target");
 
-    let output = wasm_bindgen::generate(&wasm_file)?;
+    let output = wasm_bindgen::generate(&options, &wasm_file)?;
 
     info!("compressed wasm output is {} large", pretty_size(output.compressed_wasm.len()));
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,7 @@ pub struct Options {
     pub title: String,
     pub address: String,
     pub https: bool,
+    pub no_module: bool,
 }
 
 pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<()> {
@@ -42,7 +43,12 @@ pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<(
 
     let version = generate_version();
 
-    let html = include_str!("../static/index.html").replace("{{ TITLE }}", &options.title);
+    let html = if options.no_module {
+        include_str!("../static/index_no_module.html")
+    } else {
+        include_str!("../static/index.html")
+    };
+    let html = html.replace("{{ TITLE }}", &options.title);
 
     let serve_dir = get_service(ServeDir::new(".")).handle_error(internal_server_error);
 

--- a/src/wasm_bindgen.rs
+++ b/src/wasm_bindgen.rs
@@ -1,3 +1,4 @@
+use crate::server::Options;
 use crate::Result;
 use anyhow::Context;
 use std::path::Path;
@@ -7,14 +8,19 @@ pub struct WasmBindgenOutput {
     pub js: String,
     pub compressed_wasm: Vec<u8>,
 }
-pub fn generate(wasm_file: &Path) -> Result<WasmBindgenOutput> {
+pub fn generate(options: &Options, wasm_file: &Path) -> Result<WasmBindgenOutput> {
     debug!("running wasm-bindgen...");
     let start = std::time::Instant::now();
-    let mut output = wasm_bindgen_cli_support::Bindgen::new()
-        .input_path(wasm_file)
-        .web(true)?
-        .typescript(false)
-        .generate_output()?;
+    let mut bindgen = wasm_bindgen_cli_support::Bindgen::new();
+    bindgen.input_path(wasm_file).typescript(false);
+
+    if options.no_module {
+        bindgen.no_modules(true)?;
+    } else {
+        bindgen.web(true)?;
+    }
+
+    let mut output = bindgen.generate_output()?;
     debug!("finished wasm-bindgen (took {:?})", start.elapsed());
 
     let js = output.js().to_owned();

--- a/static/index_no_module.html
+++ b/static/index_no_module.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="data:,">
+    <title>{{ TITLE }}</title>
+
+    <style>
+        body,
+        html {
+            margin: 0;
+            padding: 0;
+        }
+
+        canvas {
+            display: block;
+        }
+    </style>
+</head>
+
+<body>
+    <script src="./api/wasm.js"></script>
+    <script type="module">
+        async function run() {
+            await wasm_bindgen("/api/wasm.wasm");
+        }
+
+        const reloadInterval = 1000;
+
+        async function startReloadInterval() {
+            const fetchVersion = () => fetch("/api/version").then(response => response.text());
+            const version = await fetchVersion();
+            let intervalToken;
+
+            function reloadIfChanged() {
+                fetchVersion()
+                    .then(newVersion => {
+                        if (version != newVersion) {
+                            window.location.reload();
+                        }
+                    });
+            }
+
+            intervalToken = setInterval(reloadIfChanged, reloadInterval)
+        }
+
+        run();
+        startReloadInterval();
+    </script>
+
+    <script>
+        document.body.addEventListener("contextmenu", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This is necessary when trying to use shared memory with the same WASM file (multithreading) in browsers, as Firefox currently doesn't support JS Modules in workers.