### PR TITLE
ensure the body fills the entire view

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,8 @@
         html {
             margin: 0;
             padding: 0;
+            width: 100vw;
+            height: 100vh;
         }
 
         canvas {


### PR DESCRIPTION
Adding set width/height to the body & html ensures that they fill the entire view. This ensures that you can force bevy to fill the entire page using:
```rust
.insert_resource(WindowDescriptor {
            fit_canvas_to_parent: true,
            ..default()
        })
```