### PR TITLE
Extract get_router and add simple test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ tower = "0.4"
 fastrand = "1.5"
 brotli = { version = "3", default-features = false, features = ["std"]}
 rcgen = { version = "0.9", default-features = false }
+
+[dev-dependencies]
+tokio-test = "0.4"
+axum-test-helper = "0.1"


### PR DESCRIPTION
This PR extracts the logic from `run_server` that creates a new Router into a helper function named `get_router` to make it easier to test without needing to start the full server.

This also adds a simple test that verifies current behavior for returning a br compressed wasm.wasm file.

This change is in preparation for adding support dynamically change the available compression.

See issue #28 for context.