### PR TITLE
Remove canvas outline on focus

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,10 @@
         canvas {
             display: block;
         }
+
+        canvas:focus {
+            outline: none;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
I noticed that on Chrome focusing a canvas, for example by pressing keys, would put a black outline around the canvas. Apparently this is something Chrome specific, this PR removes this by adding `outline: none` to the stylesheet.