### PR TITLE
Add touch-action: none; to the canvas

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -19,6 +19,7 @@
 
         canvas {
             display: block;
+            touch-action: none;
         }
 
         canvas:focus {


### PR DESCRIPTION
This prevents touches from being cancelled once you start dragging (moving the touch position).