### PR TITLE
Look for `index.html` in user's static resources directory before falling back to built-in version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Default: `.`
 
 Can be used to specify where relative path requests are loaded from.
 
+If there is an `index.html` file within this directory it will be used instead of [the
+default](static/index.html).
+
 </details>
 
 <details>

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-imports_granularity="module"
-use_small_heuristics="max"
+imports_granularity = "Module"
+use_small_heuristics = "Max"

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let output = wasm_bindgen::generate(&options, &wasm_file)?;
 
-    info!("compressed wasm output is {} large", pretty_size(output.compressed_wasm.len()));
+    info!("compressed wasm output is {} in size", pretty_size(output.compressed_wasm.len()));
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(server::run_server(options, output))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,5 +53,5 @@ fn pretty_size(size_in_bytes: usize) -> String {
     }
 
     let size_in_mb = size_in_kb / 1024.0;
-    return format!("{:.2}mb", size_in_mb);
+    format!("{:.2}mb", size_in_mb)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -97,7 +97,7 @@ pub async fn run_server(options: Options, output: WasmBindgenOutput) -> Result<(
         .layer(middleware_stack);
 
     let mut address_string = options.address;
-    if !address_string.contains(":") {
+    if !address_string.contains(':') {
         address_string +=
             &(":".to_owned() + &pick_port::pick_free_port(1334, 10).unwrap_or(1334).to_string());
     }
@@ -129,12 +129,12 @@ fn get_snippet_source(
     local_modules: &HashMap<String, String>,
     snippets: &HashMap<String, Vec<String>>,
 ) -> Result<String, &'static str> {
-    let path = uri.path().trim_start_matches("/");
+    let path = uri.path().trim_start_matches('/');
     if let Some(module) = local_modules.get(path) {
         return Ok(module.clone());
     };
 
-    let (snippet, inline_snippet_name) = path.split_once("/").ok_or("invalid snippet path")?;
+    let (snippet, inline_snippet_name) = path.split_once('/').ok_or("invalid snippet path")?;
     let index = inline_snippet_name
         .strip_prefix("inline")
         .and_then(|path| path.strip_suffix(".js"))


### PR DESCRIPTION
If the user has an `index.html` file in their `WASM_SERVER_RUNNER_DIRECTORY`, `wasm-server-runner` will now use that instead of the built-in `index.html`. I had a project that required a `canvas` element, for which I needed this behaviour.

Additionally, I've fixed a few lints.

Cheers :)
