### PR TITLE
Fix viewport being too high in mobile browsers

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
             margin: 0;
             padding: 0;
             width: 100vw;
-            height: 100vh;
+            height: 100%;
         }
 
         canvas {


### PR DESCRIPTION
On android, before you scroll down, the url bar covers some of the screen space. That means the canvas created will be taller than the screen and some of it will be outside the browser.

See https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile