### PR TITLE
Remove deprecated usage of `Bindgen::weak_refs()`

### DIFF
--- a/src/wasm_bindgen.rs
+++ b/src/wasm_bindgen.rs
@@ -14,7 +14,7 @@ pub fn generate(options: &Options, wasm_file: &Path) -> Result<WasmBindgenOutput
     debug!("running wasm-bindgen...");
     let start = std::time::Instant::now();
     let mut bindgen = wasm_bindgen_cli_support::Bindgen::new();
-    bindgen.input_path(wasm_file).typescript(false).weak_refs(true).reference_types(true);
+    bindgen.input_path(wasm_file).typescript(false).reference_types(true);
 
     if options.no_module {
         bindgen.no_modules(true)?;


### PR DESCRIPTION
This is fallout from https://github.com/rustwasm/wasm-bindgen/pull/3822.

Fixes #44.