### PR TITLE
Resolve initialization warn on startup

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -34,7 +34,7 @@
         // {{ MODULE }}
 
         async function run() {
-            await wasm_bindgen("/api/wasm.wasm").catch(error => {
+            await wasm_bindgen({module_or_path: "/api/wasm.wasm"}).catch(error => {
                 if (!error.message.startsWith("Using exceptions for control flow, don't mind me. This isn't actually an error!")) {
                     throw error;
                 }


### PR DESCRIPTION
closes #48 
Currently latest version of this crate warns with `using deprecated parameters for the initialization function; pass a single object instead`
