### PR TITLE
Capture worker logs

### DIFF
--- a/example-project/examples/worker.rs
+++ b/example-project/examples/worker.rs
@@ -1,0 +1,77 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+#[wasm_bindgen(inline_js = r#"
+export function spawn_worker() {
+    const code = `
+        console.log("hello from worker");
+        console.warn("worker warning message");
+        console.error("worker error message");
+    `;
+    const blob = new Blob([code], { type: 'application/javascript' });
+    new Worker(URL.createObjectURL(blob));
+}
+
+export function spawn_worker_with_error() {
+    const code = `
+        console.log("worker about to throw");
+        throw new Error("intentional worker error");
+    `;
+    const blob = new Blob([code], { type: 'application/javascript' });
+    new Worker(URL.createObjectURL(blob));
+}
+
+export function spawn_worker_with_rejection() {
+    const code = `
+        console.log("worker about to reject");
+        Promise.reject(new Error("intentional unhandled rejection"));
+    `;
+    const blob = new Blob([code], { type: 'application/javascript' });
+    new Worker(URL.createObjectURL(blob));
+}
+
+export function spawn_worker_with_trusted_url() {
+    if (typeof trustedTypes === 'undefined') {
+        console.log("trustedTypes not supported, skipping TrustedScriptURL test");
+        return;
+    }
+
+    const code = `
+        console.log("hello from worker with TrustedScriptURL");
+    `;
+    const blob = new Blob([code], { type: 'application/javascript' });
+    const blobUrl = URL.createObjectURL(blob);
+
+    // Create a TrustedTypePolicy that allows our blob URLs
+    const policy = trustedTypes.createPolicy('worker-policy', {
+        createScriptURL: (url) => url
+    });
+    const trustedUrl = policy.createScriptURL(blobUrl);
+    new Worker(trustedUrl);
+}
+"#)]
+extern "C" {
+    fn spawn_worker();
+    fn spawn_worker_with_error();
+    fn spawn_worker_with_rejection();
+    fn spawn_worker_with_trusted_url();
+}
+
+fn main() {
+    log("spawning worker with console logs");
+    spawn_worker();
+
+    log("spawning worker that throws an error");
+    spawn_worker_with_error();
+
+    log("spawning worker with unhandled rejection");
+    spawn_worker_with_rejection();
+
+    log("spawning worker with TrustedScriptURL");
+    spawn_worker_with_trusted_url();
+}

--- a/static/index.html
+++ b/static/index.html
@@ -167,6 +167,86 @@
             };
         }
 
+        // Monkeypatch Worker to inject console forwarding
+        const OriginalWorker = Worker;
+        const workerConsoleShim = `
+            const __logMethods = ["trace", "debug", "info", "warn", "error", "log"];
+            for (const __logMethod of __logMethods) {
+                const __stdlog = console[__logMethod].bind(console);
+                console[__logMethod] = function (...args) {
+                    __stdlog(...args);
+                    postMessage({ __wasm_server_runner_log: true, level: __logMethod, args: args.map(a => {
+                        try {
+                            return (typeof a === "object" && a !== null) ? JSON.parse(JSON.stringify(a)) : a;
+                        } catch {
+                            return String(a);
+                        }
+                    })});
+                };
+            }
+            self.onerror = function(msg, src, line, col, error) {
+                postMessage({ __wasm_server_runner_error: true,
+                              message: error ? error.toString() : String(msg) });
+            };
+            self.onunhandledrejection = function(e) {
+                postMessage({ __wasm_server_runner_error: true,
+                              message: e.reason?.toString() || 'Unhandled rejection' });
+            };
+        `;
+
+        function attachWorkerLogInterceptor(worker) {
+            worker.addEventListener("message", function(event) {
+                if (event.data && event.data.__wasm_server_runner_log) {
+                    const item = [event.data.level, event.data.args];
+                    if (websocket.readyState === 1) {
+                        sendLogMessage(item);
+                    } else {
+                        queuedMessages.push(item);
+                    }
+                    event.stopImmediatePropagation();
+                }
+                if (event.data && event.data.__wasm_server_runner_error) {
+                    const item = ["error", [event.data.message]];
+                    if (websocket.readyState === 1) {
+                        sendLogMessage(item);
+                    } else {
+                        queuedMessages.push(item);
+                    }
+                    event.stopImmediatePropagation();
+                }
+            });
+            worker.onerror = function(e) {
+                console.error(e.message || 'Worker error');
+            };
+        }
+
+        // Create a TrustedTypePolicy for our shimmed worker URLs (if Trusted Types supported)
+        const workerPolicy = (typeof trustedTypes !== 'undefined')
+            ? trustedTypes.createPolicy('wasm-server-runner-worker', {
+                createScriptURL: (url) => url
+            })
+            : null;
+
+        function toScriptURL(url) {
+            return workerPolicy ? workerPolicy.createScriptURL(url) : url;
+        }
+
+        Worker = function(scriptURL, options) {
+            const resolvedURL = new URL(scriptURL, location.href).href;
+            const isModule = options?.type === "module";
+
+            // Wrap with import/importScripts to run our shim first
+            const shimCode = isModule
+                ? workerConsoleShim + `\nawait import("${resolvedURL}");`
+                : workerConsoleShim + `\nimportScripts("${resolvedURL}");`;
+            const blob = new Blob([shimCode], { type: "application/javascript" });
+            const workerOptions = isModule ? options : { ...options, type: undefined };
+            const worker = new OriginalWorker(toScriptURL(URL.createObjectURL(blob)), workerOptions);
+            attachWorkerLogInterceptor(worker);
+            return worker;
+        };
+        Worker.prototype = OriginalWorker.prototype;
+
         run();
         startReloadInterval();
     </script>


### PR DESCRIPTION
# Problem

Calls to `console.log`debug, etc., from workers are not forwarded to console.  They are silently dropped.

This is mainly a problem when you are doing `log("GOT HERE")` style debugging, to determine whether or not you actually got there, and the place you got there is a worker, and you incorrectly conclude you didn't get there, because the log isn't forwarded to console.

# Solution

Monkeypatch Worker.new() so that, each time a worker is created, its console methods are also monkeypatched in a similar way to the main page, where the logs are forwarded to console.

# Alternatives

There's an obvious risk in monkeypatching more APIs.  There are a lot of edge cases in worker types: dedicated/service/shared, blob/url, etc.  Realistically I would need help to track all the edge cases down, hence the draft.

I sent an alternative, opt-in design to wasm-bindgen-test-runner at https://github.com/wasm-bindgen/wasm-bindgen/pull/4856.  Opt-in is safer but less satisfactory.

I wanted to prototype the riskier and better approach, and it occurred to me there might be a different appetite for risk in this runner.









