### PR TITLE
Allow running behind a reverse proxy in a subpath

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -163,7 +163,7 @@ async fn handle_ws(mut socket: WebSocket) {
             _ => unreachable!("got non-text message from websocket"),
         };
 
-        let (mut level, mut text) = msg.split_once(',').unwrap();
+        let (mut level, mut text) = msg.trim_ascii().split_once(',').unwrap();
 
         if let Some(rest) = text.strip_prefix("TRACE ") {
             level = "debug";

--- a/static/index.html
+++ b/static/index.html
@@ -34,7 +34,7 @@
         // {{ MODULE }}
 
         async function run() {
-            await wasm_bindgen({module_or_path: "/api/wasm.wasm"}).catch(error => {
+            await wasm_bindgen({module_or_path: "./api/wasm.wasm"}).catch(error => {
                 if (!error.message.startsWith("Using exceptions for control flow, don't mind me. This isn't actually an error!")) {
                     throw error;
                 }
@@ -44,7 +44,7 @@
         const reloadInterval = 1000;
 
         async function startReloadInterval() {
-            const fetchVersion = () => fetch("/api/version").then(response => response.text());
+            const fetchVersion = () => fetch("./api/version").then(response => response.text());
             const version = await fetchVersion();
             let intervalToken;
 
@@ -62,7 +62,7 @@
         }
 
         let queuedMessages = [];
-        let websocket = new WebSocket(((window.location.protocol === "https:") ? "wss://" : "ws://") + window.location.host + "/ws");
+        let websocket = new WebSocket("./ws");
 
         function formatValue(value) {
             return String(value); // TODO

--- a/static/index.html
+++ b/static/index.html
@@ -44,7 +44,13 @@
         const reloadInterval = 1000;
 
         async function startReloadInterval() {
-            const fetchVersion = () => fetch("./api/version").then(response => response.text());
+            async function fetchVersion() {
+                let response = await fetch("./api/version");
+                if (!response.ok) {
+                    throw new Error();
+                }
+                return await response.text();
+            }
             const version = await fetchVersion();
             let intervalToken;
 


### PR DESCRIPTION
this is a collection of tweaks I made to improve the experience of using wasm-server-runner behind vscode’s port forwarding, where wasm-server-runner is exposed at `https://host/proxy/1334/` instead of `http://host:1334/`

- use relative urls everywhere, to allow running in a subpath
  - new browsers [support https and relative urls](https://caniuse.com/mdn-api_websocket_websocket_url_parameter_http_https_relative) in the websocket constructor, making the `wss://` logic unnecessary
- remove extra newline from forwarded console log messages
- check `fetch` response http status in `startReloadInterval`
  - fixes behavior when the reverse proxy returns http 500 status
